### PR TITLE
createCampaign with groups or segments

### DIFF
--- a/src/api/campaigns.ts
+++ b/src/api/campaigns.ts
@@ -28,7 +28,7 @@ export default function(client: AxiosInstance) {
     },
 
     async createCampaign(campaign: CampaignData) {
-      if (!campaign.groups || !campaign.segments) {
+      if (!campaign.groups && !campaign.segments) {
         throw new Error('Groups or segments have to be specified')
       }
 


### PR DESCRIPTION
Change conditional from || to && to allow only groups or segments have to be specified

It is not necessary to setup both, but the actual code throw and error if you forgot one.
In case of set groups and also segments theare are not error to create the new Campaign but later when you try to work with that campaign to add content, Mailerlite API responde with error: At least one group or segment must be selected.

So with the actual code is required both( groups and segments) to create new campaing, but this is really undefined